### PR TITLE
whitelist only the master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ script:
 after_success:
 - bash <(curl -s https://codecov.io/bash)
 # - /code/gradlew -p /code publishToTeamRepo --username=$USERNAME --password=$PASSWORD
+branches:
+  only:
+  - master
 env:
   global:
   - secure: 27QEXgoxkZnGbAVmSrbG5Sg70XRvhPpGKXzFY59IAJmt5E8F58XV9rshaaqbR9wJ77zb5UHYJmJC+aOwJCwdWBZqwC9tMiU/10Ep7qZQMIgfwNzXvRR4CJwUs2mmdlsSOVBPpRhM/RQKDqKBmTWqoMm1DZSu/dfvAIseS4aLsUjD+y1wg3rGvoC+9+GoO/yZi4Ih/Hi4i/7hINZK6FgSmtMfWZhzM0oTwRMQ6ENVGqUP7QwBoWB1yxRvzqyHIJ3CA2kPdoEXIDVFwxeEzLPSGv4RrdI3eVVFxsEqxsgKxXmKX3kSgLMJKgE6/BYFTfSMJ9F86wZEfctGwvY2LFh18REKM+mQfEkSXqakCq4ubkA47qkdFm87MOMe8KAR30IdKBHTgzRFs8b+y4esPNMpaEkbMWNxyTCnPKoJyE5Ly5MJPnDKFrlHG2MMOSDcjPVinU25B81L1Tvb5XRRpnFRcsinAneG9jEAhD6YEtW3rkcmfvLqRiAYy0r2gKsQ1tSnnXKYY+Bc5nKL/sHl8ZM2xFO3PkoYFHhkempLJ1lc3RNPUYeO2uWHgXHVsHcjwDWCacixegaTuHVIkb9cn09Rejm9/V1h5G1IIVUIsicDO+ejmbN4hy1N95ReFm9G6Qfjglq3EibdNkl3CWWNsJX/2xOyMPJ+tN0L0ra3btWSJvA=

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
 - docker
 script:
 - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
-- docker run -d -v $(pwd):/code:rw --name frc-testing-image team5499/frc-testing-image; docker exec frc-testing-image /code/gradlew -p /code test jacocoTestReport
+- docker run -t -d -v $(pwd):/code:rw --name frc-testing-image team5499/frc-testing-image; docker exec frc-testing-image /code/gradlew -p /code test jacocoTestReport
 after_success:
 - echo "$BRANCH"; if [ "$BRANCH" == "onlyBuildMasterFix" ]; then docker exec frc-testing-image /code/gradlew -p /code publishToTeamRepo --username=$USERNAME --password=$PASSWORD; fi
 - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
 - docker
 script:
 - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
-- docker run -d -v $(pwd):/code:rw --name frc-testing-image team5499/frc-testing-image; docker ps; docker exec frc-testing-image /code/gradlew -p /code test jacocoTestReport
+- docker run -d -v $(pwd):/code:rw --name frc-testing-image team5499/frc-testing-image; docker exec frc-testing-image /code/gradlew -p /code test jacocoTestReport
 after_success:
 - echo "$BRANCH"; if [ "$BRANCH" == "onlyBuildMasterFix" ]; then docker exec frc-testing-image /code/gradlew -p /code publishToTeamRepo --username=$USERNAME --password=$PASSWORD; fi
 - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
 - docker
 script:
 - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
-- docker run -v $(pwd):/code:rw --name frc-testing-image team5499/frc-testing-image; docker exec frc-testing-image /code/gradlew -p /code test jacocoTestReport
+- docker run -d -v $(pwd):/code:rw --name frc-testing-image team5499/frc-testing-image; docker exec frc-testing-image /code/gradlew -p /code test jacocoTestReport
 after_success:
 - echo "$BRANCH"; if [ "$BRANCH" == "onlyBuildMasterFix" ]; then docker exec frc-testing-image /code/gradlew -p /code publishToTeamRepo --username=$USERNAME --password=$PASSWORD; fi
 - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script:
 - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
 - docker run -v $(pwd):/code:rw team5499/frc-testing-image /code/gradlew -p /code test jacocoTestReport
 after_success:
-- echo "$BRANCH"; if [ "$BRANCH" == "onlyBuildMasterFix" ]; then docker exec -v $(pwd):/code:rw team5499/frc-testing-image /code/gradlew -p /code publishToTeamRepo --username=$USERNAME --password=$PASSWORD; fi
+- echo "$BRANCH"; if [ "$BRANCH" == "onlyBuildMasterFix" ]; then docker exec team5499/frc-testing-image /code/gradlew -p /code publishToTeamRepo --username=$USERNAME --password=$PASSWORD; fi
 - bash <(curl -s https://codecov.io/bash)
 # - /code/gradlew -p /code publishToTeamRepo --username=$USERNAME --password=$PASSWORD
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ sudo: required
 services:
 - docker
 script:
+- export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
 - docker run -v $(pwd):/code:rw team5499/frc-testing-image /code/gradlew -p /code test jacocoTestReport
 after_success:
-- echo "$TRAVIS_BRANCH"; if [ "$TRAVIS_BRANCH" == "master" ]; then docker run -v $(pwd):/code:rw team5499/frc-testing-image /code/gradlew -p /code publishToTeamRepo --username=$USERNAME --password=$PASSWORD; fi
+- echo "$BRANCH"; if [ "$BRANCH" == "master" ]; then docker run -v $(pwd):/code:rw team5499/frc-testing-image /code/gradlew -p /code publishToTeamRepo --username=$USERNAME --password=$PASSWORD; fi
 - bash <(curl -s https://codecov.io/bash)
 # - /code/gradlew -p /code publishToTeamRepo --username=$USERNAME --password=$PASSWORD
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
 - docker
 script:
 - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
-- docker run -v $(pwd):/code:rw --name frc-testing-image team5499/frc-testing-image /code/gradlew -p /code test jacocoTestReport
+- docker run -v $(pwd):/code:rw --name frc-testing-image team5499/frc-testing-image; docker exec frc-testing-image /code/gradlew -p /code test jacocoTestReport
 after_success:
 - echo "$BRANCH"; if [ "$BRANCH" == "onlyBuildMasterFix" ]; then docker exec frc-testing-image /code/gradlew -p /code publishToTeamRepo --username=$USERNAME --password=$PASSWORD; fi
 - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ services:
 - docker
 script:
 - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
-- docker run -v $(pwd):/code:rw team5499/frc-testing-image /code/gradlew -p /code test jacocoTestReport
+- docker run -v $(pwd):/code:rw --name frc-testing-image team5499/frc-testing-image /code/gradlew -p /code test jacocoTestReport
 after_success:
-- echo "$BRANCH"; if [ "$BRANCH" == "onlyBuildMasterFix" ]; then docker exec team5499/frc-testing-image /code/gradlew -p /code publishToTeamRepo --username=$USERNAME --password=$PASSWORD; fi
+- echo "$BRANCH"; if [ "$BRANCH" == "onlyBuildMasterFix" ]; then docker exec frc-testing-image /code/gradlew -p /code publishToTeamRepo --username=$USERNAME --password=$PASSWORD; fi
 - bash <(curl -s https://codecov.io/bash)
 # - /code/gradlew -p /code publishToTeamRepo --username=$USERNAME --password=$PASSWORD
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ after_success:
 - echo "$TRAVIS_BRANCH"; if [ "$TRAVIS_BRANCH" == "master" ]; then docker run -v $(pwd):/code:rw team5499/frc-testing-image /code/gradlew -p /code publishToTeamRepo --username=$USERNAME --password=$PASSWORD; fi
 - bash <(curl -s https://codecov.io/bash)
 # - /code/gradlew -p /code publishToTeamRepo --username=$USERNAME --password=$PASSWORD
-branches:
-  only:
-  - master
 env:
   global:
   - secure: 27QEXgoxkZnGbAVmSrbG5Sg70XRvhPpGKXzFY59IAJmt5E8F58XV9rshaaqbR9wJ77zb5UHYJmJC+aOwJCwdWBZqwC9tMiU/10Ep7qZQMIgfwNzXvRR4CJwUs2mmdlsSOVBPpRhM/RQKDqKBmTWqoMm1DZSu/dfvAIseS4aLsUjD+y1wg3rGvoC+9+GoO/yZi4Ih/Hi4i/7hINZK6FgSmtMfWZhzM0oTwRMQ6ENVGqUP7QwBoWB1yxRvzqyHIJ3CA2kPdoEXIDVFwxeEzLPSGv4RrdI3eVVFxsEqxsgKxXmKX3kSgLMJKgE6/BYFTfSMJ9F86wZEfctGwvY2LFh18REKM+mQfEkSXqakCq4ubkA47qkdFm87MOMe8KAR30IdKBHTgzRFs8b+y4esPNMpaEkbMWNxyTCnPKoJyE5Ly5MJPnDKFrlHG2MMOSDcjPVinU25B81L1Tvb5XRRpnFRcsinAneG9jEAhD6YEtW3rkcmfvLqRiAYy0r2gKsQ1tSnnXKYY+Bc5nKL/sHl8ZM2xFO3PkoYFHhkempLJ1lc3RNPUYeO2uWHgXHVsHcjwDWCacixegaTuHVIkb9cn09Rejm9/V1h5G1IIVUIsicDO+ejmbN4hy1N95ReFm9G6Qfjglq3EibdNkl3CWWNsJX/2xOyMPJ+tN0L0ra3btWSJvA=

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
 - docker
 script:
 - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
-- docker run -d -v $(pwd):/code:rw --name frc-testing-image team5499/frc-testing-image; docker exec frc-testing-image /code/gradlew -p /code test jacocoTestReport
+- docker run -d -v $(pwd):/code:rw --name frc-testing-image team5499/frc-testing-image; docker ps; docker exec frc-testing-image /code/gradlew -p /code test jacocoTestReport
 after_success:
 - echo "$BRANCH"; if [ "$BRANCH" == "onlyBuildMasterFix" ]; then docker exec frc-testing-image /code/gradlew -p /code publishToTeamRepo --username=$USERNAME --password=$PASSWORD; fi
 - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script:
 - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
 - docker run -v $(pwd):/code:rw team5499/frc-testing-image /code/gradlew -p /code test jacocoTestReport
 after_success:
-- echo "$BRANCH"; if [ "$BRANCH" == "master" ]; then docker run -v $(pwd):/code:rw team5499/frc-testing-image /code/gradlew -p /code publishToTeamRepo --username=$USERNAME --password=$PASSWORD; fi
+- echo "$BRANCH"; if [ "$BRANCH" == "master" ]; then docker exec -v $(pwd):/code:rw team5499/frc-testing-image /code/gradlew -p /code publishToTeamRepo --username=$USERNAME --password=$PASSWORD; fi
 - bash <(curl -s https://codecov.io/bash)
 # - /code/gradlew -p /code publishToTeamRepo --username=$USERNAME --password=$PASSWORD
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ sudo: required
 services:
 - docker
 script:
-- docker run -v $(pwd):/code:rw team5499/frc-testing-image /code/gradlew -p /code test jacocoTestReport publishToTeamRepo --username=$USERNAME --password=$PASSWORD
+- docker run -v $(pwd):/code:rw team5499/frc-testing-image /code/gradlew -p /code test jacocoTestReport
 after_success:
+- echo "$TRAVIS_BRANCH"; if [ "$TRAVIS_BRANCH" == "master" ]; then docker run -v $(pwd):/code:rw team5499/frc-testing-image /code/gradlew -p /code publishToTeamRepo --username=$USERNAME --password=$PASSWORD; fi
 - bash <(curl -s https://codecov.io/bash)
 # - /code/gradlew -p /code publishToTeamRepo --username=$USERNAME --password=$PASSWORD
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ script:
 after_success:
 - echo "$BRANCH"; if [ "$BRANCH" == "master" ]; then docker exec frc-testing-image /code/gradlew -p /code publishToTeamRepo --username=$USERNAME --password=$PASSWORD; fi
 - bash <(curl -s https://codecov.io/bash)
-# - /code/gradlew -p /code publishToTeamRepo --username=$USERNAME --password=$PASSWORD
 env:
   global:
   - secure: 27QEXgoxkZnGbAVmSrbG5Sg70XRvhPpGKXzFY59IAJmt5E8F58XV9rshaaqbR9wJ77zb5UHYJmJC+aOwJCwdWBZqwC9tMiU/10Ep7qZQMIgfwNzXvRR4CJwUs2mmdlsSOVBPpRhM/RQKDqKBmTWqoMm1DZSu/dfvAIseS4aLsUjD+y1wg3rGvoC+9+GoO/yZi4Ih/Hi4i/7hINZK6FgSmtMfWZhzM0oTwRMQ6ENVGqUP7QwBoWB1yxRvzqyHIJ3CA2kPdoEXIDVFwxeEzLPSGv4RrdI3eVVFxsEqxsgKxXmKX3kSgLMJKgE6/BYFTfSMJ9F86wZEfctGwvY2LFh18REKM+mQfEkSXqakCq4ubkA47qkdFm87MOMe8KAR30IdKBHTgzRFs8b+y4esPNMpaEkbMWNxyTCnPKoJyE5Ly5MJPnDKFrlHG2MMOSDcjPVinU25B81L1Tvb5XRRpnFRcsinAneG9jEAhD6YEtW3rkcmfvLqRiAYy0r2gKsQ1tSnnXKYY+Bc5nKL/sHl8ZM2xFO3PkoYFHhkempLJ1lc3RNPUYeO2uWHgXHVsHcjwDWCacixegaTuHVIkb9cn09Rejm9/V1h5G1IIVUIsicDO+ejmbN4hy1N95ReFm9G6Qfjglq3EibdNkl3CWWNsJX/2xOyMPJ+tN0L0ra3btWSJvA=

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script:
 - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
 - docker run -t -d -v $(pwd):/code:rw --name frc-testing-image team5499/frc-testing-image; docker exec frc-testing-image /code/gradlew -p /code test jacocoTestReport
 after_success:
-- echo "$BRANCH"; if [ "$BRANCH" == "onlyBuildMasterFix" ]; then docker exec frc-testing-image /code/gradlew -p /code publishToTeamRepo --username=$USERNAME --password=$PASSWORD; fi
+- echo "$BRANCH"; if [ "$BRANCH" == "master" ]; then docker exec frc-testing-image /code/gradlew -p /code publishToTeamRepo --username=$USERNAME --password=$PASSWORD; fi
 - bash <(curl -s https://codecov.io/bash)
 # - /code/gradlew -p /code publishToTeamRepo --username=$USERNAME --password=$PASSWORD
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script:
 - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
 - docker run -v $(pwd):/code:rw team5499/frc-testing-image /code/gradlew -p /code test jacocoTestReport
 after_success:
-- echo "$BRANCH"; if [ "$BRANCH" == "master" ]; then docker exec -v $(pwd):/code:rw team5499/frc-testing-image /code/gradlew -p /code publishToTeamRepo --username=$USERNAME --password=$PASSWORD; fi
+- echo "$BRANCH"; if [ "$BRANCH" == "onlyBuildMasterFix" ]; then docker exec -v $(pwd):/code:rw team5499/frc-testing-image /code/gradlew -p /code publishToTeamRepo --username=$USERNAME --password=$PASSWORD; fi
 - bash <(curl -s https://codecov.io/bash)
 # - /code/gradlew -p /code publishToTeamRepo --username=$USERNAME --password=$PASSWORD
 env:


### PR DESCRIPTION
Travis CI should only build and publish from the master branch. We should figure out how to build for every branch, and make Travis only publish if it is building the master branch.